### PR TITLE
fix: db import from ".env" to "ref_geo.env"

### DIFF
--- a/src/ref_geo/models.py
+++ b/src/ref_geo/models.py
@@ -10,7 +10,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from utils_flask_sqla.serializers import serializable
 from utils_flask_sqla_geo.serializers import geoserializable
 
-from .env import db
+from ref_geo.env import db
 
 from sqlalchemy.ext.hybrid import hybrid_property
 


### PR DESCRIPTION
On préfère ici utiliser le chemin `ref_geo.env` au lieu de `.env`.

Le chemin introduit des confusions de chemins, par exemple lors de l'utilisation d'un debugger au niveau de l'appli GeoNature. 

De plus, c'est la forme de chemin utilisée ailleurs dans ref_geo (`commands`, `conftest`, `models`, `route`, `schema`, `test_ref_geo`)