### PR TITLE
Drop redundant indexes on ref_geo

### DIFF
--- a/src/ref_geo/migrations/versions/b26fdaae0528_drop_duplicate_indexes.py
+++ b/src/ref_geo/migrations/versions/b26fdaae0528_drop_duplicate_indexes.py
@@ -1,0 +1,59 @@
+"""Drop duplicate indexes.
+
+Revision ID: b26fdaae0528
+Revises: 1ca7fd0d2ea
+Create Date: 2025-06-16 17:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b26fdaae0528"
+down_revision = "1ca7fd0d2ea"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Drops some unique indexes
+    redundants with unique constraints on the same columns.
+    """
+
+    # redundant with unique_id_type_area_code
+    op.drop_index(
+        "i_unique_l_areas_id_type_area_code",
+        schema="ref_geo",
+        table_name="l_areas",
+        if_exists=True,
+    )
+
+    # redundant with unique_bib_areas_types_type_code
+    op.drop_index(
+        "i_unique_bib_areas_types_type_code",
+        schema="ref_geo",
+        table_name="bib_area_types",
+        if_exists=True,
+    )
+
+
+def downgrade():
+    """Creates back the redundant indexes."""
+
+    op.create_index(
+        "i_unique_l_areas_id_type_area_code",
+        schema="ref_geo",
+        table_name="l_areas",
+        columns=["id_type", "area_code"],
+        unique=True,
+    )
+
+    op.create_index(
+        "i_unique_bib_areas_types_type_code",
+        schema="ref_geo",
+        table_name="bib_area_types",
+        columns=["type_code"],
+        unique=True,
+    )


### PR DESCRIPTION
Une PR qui termine le nettoyage d'index redondants initié par la PR GeoNature [#3562](https://github.com/PnX-SI/GeoNature/pull/3562). 

On s'attaque cette fois à deux index déclarés sur le référentiel géographique, au niveau des tables bib_area_types et l_area. Là encore, le gain est faible (quoi que la table l_areas peut être assez conséquente, chez moi la suppression de `i_unique_l_areas_id_type_area_code` a libéré 2 Mo :sparkles: )
